### PR TITLE
Two bugfixes on handling errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function TeamSpeakClient(host, port){
 				response = parseResponse(s.substr("error ".length).trim());
 				executing.error = response;
 				if(executing.error.id === "0") delete executing.error;
-				if(executing.cb) executing.cb.call(executing, executing.result, executing.response);
+				if(executing.cb) executing.cb.call(executing, executing.error, executing.response);
 				executing = null;
 				checkQueue();
 			} else if(s.indexOf("notify") === 0){


### PR DESCRIPTION
Hi, this pull-request fixes two bugs:
- Errors were not [deleted](https://github.com/gwTumm/node-teamspeak/blame/master/index.js#L128) since 36b99fb1.
- Errors were not transmitted (the variable `executing.result` does not exist).
