### PR TITLE
Allow params to contain arrays of non-strings (eg. numbers)

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ function TeamSpeakClient(host, port){
 		executing = null;
 	
 	function tsescape(s){
-		var r = s.replace(/\\/g, "\\\\");// Backslash
+		var r = String(s);
+		r = r.replace(/\\/g, "\\\\");// Backslash
 		r = r.replace(/\//g, "\\/");     // Slash
 		r = r.replace(/\|/g, "\\p");     // Pipe
 		r = r.replace(/\n/g, "\\n");     // Newline


### PR DESCRIPTION
When doing a `clientmove`, sometimes I have an array of `clid` numbers (and not strings) from a prior `clientlist` response. This fix allows that to work (among other things).
