### PR TITLE
Bugfix: rawResponse was not transmitted

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,8 @@ function TeamSpeakClient(host, port){
 				response = parseResponse(s.substr("error ".length).trim());
 				executing.error = response;
 				if(executing.error.id === "0") delete executing.error;
-				if(executing.cb) executing.cb.call(executing, executing.error, executing.response);
+				if(executing.cb) executing.cb.call(executing, executing.error, executing.response,
+					executing.rawResponse);
 				executing = null;
 				checkQueue();
 			} else if(s.indexOf("notify") === 0){


### PR DESCRIPTION
There was an error in the merge, so the new argument "rawResponse" from #7 was not transmitted.
