### PR TITLE
fix errors being triggered on successful requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function TeamSpeakClient(host, port){
 			if(s.indexOf("error") === 0){
 				response = parseResponse(s.substr("error ".length).trim());
 				executing.error = response;
-				if(executing.error.id === "0") delete executing.error;
+				if(executing.error.id === 0) delete executing.error;
 				if(executing.cb) executing.cb.call(executing, executing.error, executing.response,
 					executing.rawResponse);
 				executing = null;


### PR DESCRIPTION
The error id is a number not a string, stops errors being triggered incorrectly
